### PR TITLE
Keep history between shell invocations.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* Save the history between invocations of the
+  shell.
+
 Changes for 0.9123      Fri Mar 30 16:46:52 2012
 ================================================
 * Added support for adding blib/script to PATH

--- a/lib/CPANPLUS/Config.pm
+++ b/lib/CPANPLUS/Config.pm
@@ -282,6 +282,15 @@ etc. Defaults to 'false'.
 
         $Conf->{'conf'}->{'force'} = 0;
 
+=item histfile
+
+A string containing the history filename of the CPANPLUS readline instance.
+
+=cut
+
+        $Conf->{'conf'}->{'histfile'} = File::Spec->catdir(
+                                        __PACKAGE__->_home_dir, DOT_CPANPLUS, 'history' );
+
 =item lib
 
 An array ref holding directories to be added to C<@INC> when CPANPLUS

--- a/lib/CPANPLUS/Shell/Default.pm
+++ b/lib/CPANPLUS/Shell/Default.pm
@@ -213,6 +213,20 @@ sub new {
     ### load all the plugins
     $self->_plugins_init;
 
+    if (my $histfile = $cb->configure_object->get_conf( 'histfile' )) {
+        my $term = $self->term;
+        if ($term->can('AddHistory')) {
+            if (open my $fh, '<', $histfile) {
+                local $/ = "\n";
+                while (my $line = <$fh>) {
+                    chomp($line);
+                    $term->AddHistory($line);
+                }
+                close($fh);
+            }
+        }
+    }
+
     return $self;
 }
 
@@ -511,9 +525,26 @@ sub __display_results {
 
 sub _quit {
     my $self = shift;
+    my $term = $self->term;
 
     $self->dispatch_on_input( input => $rc->{'logout'} )
             if defined $rc->{'logout'};
+
+    if ($term->can('GetHistory')) {
+        my @history = $term->GetHistory;
+
+        my $histfile = $self->backend->configure_object->get_conf('histfile');
+
+        if (open my $fh, '>', $histfile) {
+            foreach my $line (@history) {
+                print {$fh} "$line\n";
+            }
+            close($fh);
+        }
+        else {
+            warn "Cannot open history file '$histfile' - $!";
+        }
+    }
 
     $self->__print( loc("Exiting CPANPLUS shell"), "\n" );
 


### PR DESCRIPTION
Hi all,

the problem with the history not being remembered in CPANPLUS has been bothering me and now I've decided to do something about it and did. Please pull. 

Keep the history inside 'histfile' between shell invocations, so the
comands will be remembered. I used the CPAN.pm code as reference, but
the code here is original.

TODO : add a way to configure how many lines to remember.
