### PR TITLE
Always re-fetch CHECKSUMS if fetchdir is set

### DIFF
--- a/lib/CPANPLUS/Module/Checksums.pm
+++ b/lib/CPANPLUS/Module/Checksums.pm
@@ -142,7 +142,14 @@ sub _get_checksums_file {
     my $clone = $self->clone;
     $clone->package( CHECKSUMS );
 
-    my $file = $clone->fetch( ttl => 3600, %hash ) or return;
+    # If the user specified a fetchdir, then every CHECKSUMS file will always
+    # be stored there, not in an author-specific subdir.  Thus, in this case,
+    # we need to always re-fetch the CHECKSUMS file and hence need to set the
+    # TTL to something small.
+    my $have_fetchdir =
+        $self->parent->configure_object->get_conf('fetchdir') ne '';
+    my $ttl = $have_fetchdir ? 0.001 : 3600;
+    my $file = $clone->fetch( ttl => $ttl, %hash ) or return;
 
     return $file;
 }


### PR DESCRIPTION
If the user specifies a fetchdir in the configuration, then every file
fetched from CPAN is placed directly in the fetchdir, not in an
author-specific subdir.  Thus, there can only be one CHECKSUMS file and
we need to re-fetch it every time we want to test a checksum.

I consider this a hack to get checksum testing working.  Ideally, I think CPANPLUS would simply create the same author-specific subdir structure under fetchdir that it creates when fetchdir is not set.  I tried implementing this but encountered too many problems due to things assuming that, with fetchdir set, things are stored in the top-level.
