### PR TITLE
Implement x_use_unsafe_inc meta behaviour RT#121656

### DIFF
--- a/lib/CPANPLUS/Dist.pm
+++ b/lib/CPANPLUS/Dist.pm
@@ -143,7 +143,7 @@ sub new {
 
         ### add minimum supported accessors
         $acc->mk_accessors( qw[prepared created installed uninstalled
-                               distdir dist] );
+                               distdir dist _metadata] );
     }
 
     ### get the conf object ###
@@ -305,6 +305,8 @@ sub find_configure_requires {
         file => { store => \$meta },
     };
 
+    $self->_stash_metadata(); # Okay hacks.
+
     check( $tmpl, \%hash ) or return;
 
     my $meth = 'configure_requires';
@@ -422,7 +424,7 @@ sub _prereqs_from_meta_file {
         ### Parse::CPAN::Meta uses exceptions for errors
         ### hash returned in list context!!!
 
-        local $ENV{PERL_JSON_BACKEND};
+        local $ENV{PERL_YAML_BACKEND};
 
         my ($doc) = eval { Parse::CPAN::Meta::LoadFile( $meta ) };
 
@@ -501,6 +503,45 @@ sub _prereqs_from_meta_json {
     ### and return a copy
     return \%{ $defaults };
 }
+
+sub _stash_metadata {
+    my $self = shift;
+    my $mod  = $self->parent;
+
+    my @possibles = do { defined $mod->status->extract
+                         ? ( META_JSON->( $mod->status->extract ),
+                             META_YML->( $mod->status->extract ) )
+                         : ()
+                    };
+
+    $self->mk_accessors( qw[_metadata] );
+    $self->status->_metadata( {} );
+
+    META: foreach my $mfile ( grep { -e } @possibles ) {
+        if ( $mfile =~ /\.json/ ) {
+            local $ENV{PERL_JSON_BACKEND};
+            my ($doc) = eval { Parse::CPAN::Meta->load_file( $mfile ) };
+            unless( $doc ) {
+              error(loc( "Could not read %1: '%2'", $mfile, $@ ));
+              return;
+            }
+            $self->status->_metadata( $doc );
+            return $doc;
+        }
+        else {
+            local $ENV{PERL_YAML_BACKEND};
+            my ($doc) = eval { Parse::CPAN::Meta->load_file( $mfile ) };
+            unless( $doc ) {
+              error(loc( "Could not read %1: '%2'", $mfile, $@ ));
+              return;
+            }
+            $self->status->_metadata( $doc );
+            return $doc;
+        }
+    }
+    return;
+}
+
 
 =head2 $bool = $dist->_resolve_prereqs( ... )
 

--- a/lib/CPANPLUS/Dist/Autobundle.pm
+++ b/lib/CPANPLUS/Dist/Autobundle.pm
@@ -33,7 +33,7 @@ sub init {
     my $status  = $dist->status;
 
     $status->mk_accessors(
-        qw[prepared created installed _prepare_args _create_args _install_args]
+        qw[prepared created installed _prepare_args _create_args _install_args _metadata]
     );
 
     return 1;

--- a/lib/CPANPLUS/Dist/MM.pm
+++ b/lib/CPANPLUS/Dist/MM.pm
@@ -171,7 +171,7 @@ sub init {
     my $status  = $dist->status;
 
     $status->mk_accessors(qw[makefile make test created installed uninstalled
-                             bin_make _prepare_args _create_args _install_args]
+                             bin_make _prepare_args _create_args _install_args _metadata]
                         );
 
     return 1;
@@ -261,9 +261,6 @@ sub prepare {
     my $fail;
     RUN: {
 
-        local $ENV{PERL_USE_UNSAFE_INC} = 1
-          unless exists $ENV{PERL_USE_UNSAFE_INC};
-
         ### we resolve 'configure requires' here, so we can run the 'perl
         ### Makefile.PL' command
         ### XXX for tests: mock f_c_r to something that *can* resolve and
@@ -294,7 +291,12 @@ sub prepare {
             ### end of prereq resolving ###
         }
 
+        my $metadata = $dist->status->_metadata;
+        my $x_use_unsafe_inc = ( defined $metadata && exists $metadata->{x_use_unsafe_inc} ? $metadata->{x_use_unsafe_inc} : undef );
+        $x_use_unsafe_inc = 1 unless defined $x_use_unsafe_inc;
 
+        local $ENV{PERL_USE_UNSAFE_INC} = $x_use_unsafe_inc
+          unless exists $ENV{PERL_USE_UNSAFE_INC};
 
         ### don't run 'perl makefile.pl' again if there's a makefile already
         if( -e MAKEFILE->() && (-M MAKEFILE->() < -M $dir) && !$force ) {
@@ -614,7 +616,11 @@ sub create {
     my $status = { };
     RUN: {
 
-        local $ENV{PERL_USE_UNSAFE_INC} = 1
+        my $metadata = $dist->status->_metadata;
+        my $x_use_unsafe_inc = ( defined $metadata && exists $metadata->{x_use_unsafe_inc} ? $metadata->{x_use_unsafe_inc} : undef );
+        $x_use_unsafe_inc = 1 unless defined $x_use_unsafe_inc;
+
+        local $ENV{PERL_USE_UNSAFE_INC} = $x_use_unsafe_inc
           unless exists $ENV{PERL_USE_UNSAFE_INC};
 
         ### this will set the directory back to the start
@@ -839,7 +845,11 @@ sub install {
 
     my $fail; my $captured;
 
-    local $ENV{PERL_USE_UNSAFE_INC} = 1
+    my $metadata = $dist->status->_metadata;
+    my $x_use_unsafe_inc = ( defined $metadata && exists $metadata->{x_use_unsafe_inc} ? $metadata->{x_use_unsafe_inc} : undef );
+    $x_use_unsafe_inc = 1 unless defined $x_use_unsafe_inc;
+
+    local $ENV{PERL_USE_UNSAFE_INC} = $x_use_unsafe_inc
       unless exists $ENV{PERL_USE_UNSAFE_INC};
 
     ### 'make install' section ###

--- a/t/04_CPANPLUS-Module.t
+++ b/t/04_CPANPLUS-Module.t
@@ -310,6 +310,7 @@ SKIP: {   ### details() test ###
 
 }
 
+
 ### test module from perl core ###
 {   isa_ok( $CoreMod, 'CPANPLUS::Module',
                                 "Core module " . $CoreName );


### PR DESCRIPTION
Stash META.[yml|json] data and use it to determine whether to
set PERL_USE_UNSAFE_INC environment variable.

If PERL_USE_UNSAFE_INC is already set in the environment
then x_use_unsafe_inc is ignored.