### PR TITLE
Do not run t/08_CPANPLUS-Backend.t parallel

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -161,3 +161,4 @@ t/dummy-perl/lib/.hidden
 t/dummy-perl/man/man1/.hidden
 t/dummy-perl/man/man3/.hidden
 t/inc/conf.pl
+t/testrules.yml

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -1,0 +1,4 @@
+# CPAN RT#59085
+seq:
+    - seq: 't/08_CPANPLUS-Backend.t'
+    - par: '**'


### PR DESCRIPTION
When running tests in parallel, tests sometimes fail and always in
t/08_CPANPLUS-Backend.t. This patch defines test rules for
TAP::Harness to run t/08_CPANPLUS-Backend.t always isolated.

https://rt.cpan.org/Ticket/Display.html?id=59085