### PR TITLE
Add shebang to cpanp-run-perl

### DIFF
--- a/bin/cpanp-run-perl
+++ b/bin/cpanp-run-perl
@@ -1,3 +1,4 @@
+#!perl
 use strict;
 BEGIN {
 my $old = select STDERR; $|++;  # turn on autoflush


### PR DESCRIPTION
cpanp-run-perl is installed as an executable script among other script and as such it should have a proper shebbang.