### PR TITLE
break circular dependency between CPANPLUS::Internals::Constants::Report and CPANPLUS::Internals::Report

### DIFF
--- a/lib/CPANPLUS/Internals/Constants/Report.pm
+++ b/lib/CPANPLUS/Internals/Constants/Report.pm
@@ -11,9 +11,6 @@ use vars    qw[$VERSION @ISA @EXPORT];
 
 use Package::Constants;
 
-### for the version
-require CPANPLUS::Internals;
-
 $VERSION = "0.9910";
 @ISA        = qw[Exporter];
 @EXPORT     = Package::Constants->list( __PACKAGE__ );


### PR DESCRIPTION
We have the following situation:
- CPANPLUS::Internals::Constants::Report requires CPANPLUS::Internals
- CPANPLUS::Internals uses CPANPLUS::Internals::Report
- CPANPLUS::Internals::Report uses CPANPLUS::Internals::Constant::Report

As a consequence, any attempt to load
CPANPLUS::Internals::Constants::Report fails, because of constants not
yet available in CPANPLUS::Internals:
$> perl -MCPANPLUS::Internals::Constants::Report
Bareword "GRADE_NA" not allowed while "strict subs" in use at /usr/share/perl5/vendor_perl/CPANPLUS/Internals/Report.pm line 366.
Bareword "GRADE_NA" not allowed while "strict subs" in use at /usr/share/perl5/vendor_perl/CPANPLUS/Internals/Report.pm line 388.
...
Compilation failed in require at /usr/share/perl5/vendor_perl/CPANPLUS/Internals.pm line 19.
BEGIN failed--compilation aborted at /usr/share/perl5/vendor_perl/CPANPLUS/Internals.pm line 19.
Compilation failed in require at /usr/share/perl5/vendor_perl/CPANPLUS/Internals/Constants/Report.pm line 15.
Compilation failed in require.
BEGIN failed--compilation aborted.

While this may seem harmless, this is actually quite painful, as bash
completion for cpan2dist command --format argument does try to load this
class in order to provides completions. And as the only justification of
this circular dependency seems to have been able to access a version
variable defined in CPANPLUS::Internals, which is now defined below
explicitely, it seems useless currently.